### PR TITLE
removed special EICAR result case to maintain API consistency

### DIFF
--- a/clamd.go
+++ b/clamd.go
@@ -33,12 +33,12 @@ const (
 	cmdScan             = "SCAN"
 	cmdContscan         = "CONTSCAN"
 	resOk               = "OK"
+	resFound            = "FOUND"
 	resPong             = "PONG"
 	resReloading        = "RELOADING"
 	resNoSuchFile       = "No such file or directory. ERROR"
 	resPermissionDenied = "Permission denied. ERROR"
 	resCantOpenFile     = "Can't open file or directory ERROR"
-	resEICAR            = "Win.Test.EICAR_HDB-1 FOUND"
 )
 
 // NewClamd returns a Clamd client with default options.
@@ -238,8 +238,8 @@ func parseErr(res string, err error) (bool, error) {
 	if strings.HasSuffix(res, resOk) {
 		return true, nil
 	}
-	if strings.HasSuffix(res, resEICAR) {
-		return false, errors.Join(ErrEICARFound, fmt.Errorf("%s", res))
+	if strings.HasSuffix(res, resFound) {
+		return false, nil
 	}
 	if strings.HasSuffix(res, resNoSuchFile) {
 		return false, errors.Join(ErrNoSuchFileOrDir, fmt.Errorf("%s", res))

--- a/clamd_test.go
+++ b/clamd_test.go
@@ -2,7 +2,6 @@ package clamd
 
 import (
 	"context"
-	"errors"
 	"log"
 	"os"
 	"path"
@@ -76,7 +75,7 @@ func TestScan(t *testing.T) {
 	defer os.Remove(tf)
 
 	got, err := clamd.Scan(context.Background(), tf)
-	if err != nil && !errors.Is(err, ErrEICARFound) {
+	if err != nil {
 		t.Errorf("%v", err)
 	}
 	if got {
@@ -96,7 +95,7 @@ func TestStream(t *testing.T) {
 	}
 
 	got, err := clamd.ScanStream(context.Background(), f)
-	if err != nil && !errors.Is(err, ErrEICARFound) {
+	if err != nil {
 		t.Errorf("%v", err)
 	}
 	if got {
@@ -111,7 +110,7 @@ func TestScanAll(t *testing.T) {
 	defer os.Remove(tf)
 
 	got, err := clamd.ScanAll(context.Background(), tf)
-	if err != nil && !errors.Is(err, ErrEICARFound) {
+	if err != nil {
 		t.Errorf("%v", err)
 	}
 	if got {

--- a/errors.go
+++ b/errors.go
@@ -14,5 +14,4 @@ var (
 	ErrCantOpenFile       = errors.New("clamd can't open file or dir")
 	ErrSreamLimitExceeded = errors.New("clamd's INSTREAM size limit exceeded")
 	ErrUnknown            = errors.New("unknown error")
-	ErrEICARFound         = errors.New("Win.Test.EICAR_HDB-1 FOUND")
 )


### PR DESCRIPTION
I removed the special EICAR cases for tests because when we were using this library and testing that it worked we were getting an error string that didn't match the "Win.Test.EICAR_HDB-1 FOUND" string. It said "stream: Eicar-Signature FOUND" instead. This resulted in an unknown error being returned.

I decided that it would be better if this case wasn't in there at all, and that the API would return a false value as it would if any other malware was detected.